### PR TITLE
Updating/Refining categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,17 @@ threeJS https://github.com/mrdoob/three.js/
  
  
 ### SDKs
-ARCore https://developers.google.com/ar/ \
+ARCore SDK https://developers.google.com/ar/develop/ \
 CameraKit SDK https://kit.snapchat.com/camera-kit \
 Cloud XR SDK https://developer.nvidia.com/nvidia-cloudxr-sdk \
 Easy AR https://www.easyar.com/ \
-Google VR SDK https://developers.google.com/vr/develop/unity/get-started-android \
+Google Cardboard SDK https://developers.google.com/cardboard/develop \
 LightShip https://lightship.dev/ \
 Lumin SDK https://developer.magicleap.com/downloads/lumin-sdk/ \
 Mixed Reality Extension SDK https://github.com/Microsoft/mixed-reality-extension-sdk \
 MRTK https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-unity/ \
 Normcore https://normcore.io/ \
 Oculus SDK https://developer.oculus.com/ \
-OpenVR SDK https://github.com/ValveSoftware/openvr \
 Photon https://www.photounengine.com/sdks \
 Tobii XR SDK https://vr.tobii.com/sdk/ \
 Vive Sense SDK https://developer.vive.com/resources/vive-sense/ \
@@ -51,50 +50,48 @@ VRTK https://www.vrtk.io/ \
 Vuforia https://developer.vuforia.com/downloads/sdk \
 Wikitude https://www.wikitude.com/products/wikitude-sdk/ \
 XRTK https://xrtk.io/ 
- 
+
+
 ### APIs
-Advanced API https://vr.tobii.com/sdk/develop/unity/documentation/api-reference/ \
-ARCore https://arvr.google.com/arcore/ \
-Core API https://vr.tobii.com/sdk/develop/unity/documentation/api-reference/ \
-Mozilla WebVR https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API/Fundamentals \
 Oculus https://dashboard.oculus.com/app/api \
-Open XR https://www.khronos.org/OpenXR/ \
+OpenXR https://www.khronos.org/OpenXR/ \
 WebAudio https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API \
 WebXR https://developer.mozilla.org/en-US/docs/Web/API/WebXR_Device_API 
- 
+
+
 ### Protocols
 REST https://docs.github.com/en/rest \
 SOAP https://www.w3.org/TR/soap/ \
 WebRTC https://webrtc.org/ \
-Websockets https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API
- 
+WebSockets https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API
+
+
 ### Databases
 MySQL https://dev.mysql.com/doc/ \
 NoSQL https://docs.oracle.com/en/database/other-databases/nosql-database/ \
 PostgreSQL https://www.postgresql.org/docs/ \
-VRML https://www.w3.org/MarkUp/VRML/ \
-WebRTC https://webrtc.org/ \
-Websockets https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API \
-X3D https://www.web3d.org/x3d/what-x3d \
-xVRML https://sourceforge.net/projects/xvrml/
- 
+Redis https://redis.io/ \
+MongoDB https://www.mongodb.com/
+
+
 ### Backend
 .NET https://docs.microsoft.com/en-us/dotnet/ \
 C# https://docs.microsoft.com/en-us/dotnet/csharp/ \
 C++ https://www.cplusplus.com/doc/tutorial/ \
 Java https://docs.oracle.com/en/java/ \
-lua https://www.lua.org/docs.html \
+Lua https://www.lua.org/docs.html \
 Node.JS https://nodejs.org/en/docs/ \
 Objective-C https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011210 \
 Python https://docs.python.org/3/ \
 Ruby https://www.ruby-lang.org/en/documentation/ \
 Swift https://www.swift.org/documentation/ 
- 
- 
+
+
 ### Platforms
 8th Wall Reality Engine https://www.8thwall.com/tutorials \
 Amazon Sumerian https://aws.amazon.com/sumerian/ \
 Android https://developer.android.com/ \
+ARCore https://arvr.google.com/arcore/ \
 Azure https://azure.microsoft.com/ \
 iOS https://developer.apple.com/ios/ \
 Lens Studio https://www.lensstudio.snapchat.com/    


### PR DESCRIPTION
To explain my changes:

- ARCore is Google's AR platform, of which there is an SDK, so I've listed it appropriately in those areas.
- Google's VR SDK was deprecated back in 2019 in favor of their Cardboard SDK.
- OpenVR itself is an API and not an SDK (the included repo is simply an SDK that implements said API) but it is also being deprecated in favor of OpenXR.
- Advanced API and Core API don't make any sense being here, especially because they're referring to the API references for Tobii's XR SDK, which is already on this list.
- WebVR has essentially been fully deprecated in favor of WebXR and was even removed from Chrome back in version 80.
- VRML, xVRML, and X3D are not databases, they are file formats/standards for viewing+displaying 3D content on the web. None of these see any significant usage today. WebRTC and WebSockets are also not databases, they are clearly protocols as listed directly before, so not sure why they were here to begin with.